### PR TITLE
Added support for environment variables JUPYROS_WEBSOCKET_URL and JUPYROS_ASSETS_URL so that JupyROS can work on remote computers

### DIFF
--- a/js/lib/defaults.js
+++ b/js/lib/defaults.js
@@ -19,7 +19,7 @@ var URDFModelDefaults =     {
         _view_module: "jupyter-ros",
         _view_module_version: "^0.1.0",
         _view_name: "URDFView",
-        path: "http://localhost:3000",
+        path: "http://" + window.location.hostname + ":3000",
         ros: undefined,
         tf_client: undefined,
     }
@@ -91,7 +91,7 @@ var ROSConnectionModelDefaults =     {
         _model_module_version: "^0.1.0",
         _model_name: "ROSConnectionModel",
         port: "9090",
-        url: "ws://localhost",
+        url: "ws://" + window.location.hostname,
     }
     
     

--- a/jupyros/ros3d.py
+++ b/jupyros/ros3d.py
@@ -1,6 +1,9 @@
+import os
+
 import ipywidgets as widgets
 from traitlets import *
 from ._version import version_info
+
 
 def _quick_widget(package_name, version, has_view=True):
     def quick_widget_decorator(cls):
@@ -42,7 +45,9 @@ sync_widget.update(widgets.widget_serialization)
 
 @register_noview
 class ROSConnection(widgets.Widget):
-    url = Unicode("ws://localhost:9090").tag(sync=True)
+    url = Unicode(
+        os.environ.get("JUPYROS_WEBSOCKET_URL", "ws://localhost:9090")
+    ).tag(sync=True)
 
 @register_noview
 class TFClient(widgets.Widget):
@@ -56,7 +61,9 @@ class TFClient(widgets.Widget):
 class URDFModel(widgets.Widget):
     ros = Instance(ROSConnection).tag(**sync_widget)
     tf_client = Instance(TFClient).tag(**sync_widget)
-    url = Unicode("http://localhost:3000").tag(sync=True)
+    url = Unicode(
+        os.environ.get("JUPYROS_ASSETS_URL", "http://localhost:3000")
+    ).tag(sync=True)
 
 @register
 class GridModel(widgets.Widget):

--- a/notebooks/ROS Robo.ipynb
+++ b/notebooks/ROS Robo.ipynb
@@ -36,7 +36,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import ros3d"
+    "import ros3d\n",
+    "import os"
    ]
   },
   {
@@ -89,7 +90,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "urdf = ros3d.URDFModel(ros=rc, tf_client=tf_client, path='http://localhost:3000/')"
+    "urdf = ros3d.URDFModel(ros=rc, tf_client=tf_client, path=os.environ.get('JUPYROS_ASSETS_URL', 'http://localhost:3000'))"
    ]
   },
   {
@@ -128,6 +129,15 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.3"
+  },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "source": [],
+    "metadata": {
+     "collapsed": false
+    }
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
JupyROS works great on local computers, but making it work remotely can be really time consuming.

To make this task easier, in this PR we add the two following environment variables:

- JUPYROS_WEBSOCKET_URL
- JUPYROS_ASSETS_URL

The way you could set them before launching Jupyter would be as follows:

```
export JUPYROS_WEBSOCKET_URL=ws://YOUR_IP_ADDRESS:9090
export JUPYROS_ASSETS_URL=http://YOUR_IP_ADDRESS:3000
```

After that, you could launch Jupyter and everything should work fine.

If these variables are not provided, their default values would be `ws://localhost:9090` and `http://localhost:3000` respectively.