### PR TITLE
Fix envs if JUPYROS_DEFAULT_WS is not specified

### DIFF
--- a/jupyros/server_extension.py
+++ b/jupyros/server_extension.py
@@ -18,7 +18,7 @@ __version__ = _version.__version__
 if os.getenv('JUPYROS_DEFAULT_WS'):
     envs = os.getenv('JUPYROS_DEFAULT_WS').split(';')
 else:
-    envs = []
+    envs = None
 r = rospkg.RosPack(envs)
 
 class ROSStaticHandler(IPythonHandler):


### PR DESCRIPTION
It just took me ages to figure this out. If envs is set to an empty list, no packages are found. Instead, if set to None, the default behaviour is used (whatever that is) and packages are found.