### PR TITLE
Make actionlib dependency optional

### DIFF
--- a/jupyros/ros_widgets.py
+++ b/jupyros/ros_widgets.py
@@ -23,7 +23,11 @@ import ipywidgets as widgets
 import numpy as np
 import threading
 import subprocess, yaml, os
-import actionlib
+
+try: 
+    import actionlib
+except:
+    print("The actionlib package is not found in your $PYTHONPATH. Action clients are not going to work.")
 
 
 def add_widgets(msg_instance, widget_dict, widget_list, prefix=''):

--- a/notebooks/ROS Actions.ipynb
+++ b/notebooks/ROS Actions.ipynb
@@ -26,7 +26,6 @@
     "import jupyros\n",
     "import rospy\n",
     "from actionlib_tutorials.msg import FibonacciAction, FibonacciGoal, FibonacciFeedback, FibonacciResult\n",
-    "import actionlib\n",
     "\n",
     "rospy.init_node(\"fibonacci_client\")"
    ]


### PR DESCRIPTION
To use the action widgets, it is necessary to have the actionlib library. But this should be an optional dependency to avoid conflicts with ROS2.
The required packages to run the ROS Actions notebook are listed as:
- `ros-noetic-actionlib`
- `ros-noetic-actionlib-tutorials`

With this PR, these two packages remain optional.