### PR TITLE
Prepare repository for ROS2

### DIFF
--- a/jupyros/__init__.py
+++ b/jupyros/__init__.py
@@ -8,12 +8,12 @@
 
 from ._version import version_info, __version__
 
-from .ros_widgets import *
-from .pubsub import *
-from .ipy import *
-from .server_extension import *
-
-from .ros3d import *
+from .ros1.ipy import *
+from .ros1.pubsub import *
+from .ros1.ros_widgets import *
+from .ros1.ros3d import *
+from .ros1.server_extension import *
+from .ros1.turtle_sim import *
 
 def _jupyter_nbextension_paths():
     return [{

--- a/jupyros/ros1/__init__.py
+++ b/jupyros/ros1/__init__.py
@@ -1,0 +1,16 @@
+#############################################################################
+# Copyright (c) Wolf Vollprecht, QuantStack                                 #
+#                                                                           #
+# Distributed under the terms of the BSD 3-Clause License.                  #
+#                                                                           #
+# The full license is in the file LICENSE, distributed with this software.  #
+#############################################################################
+
+from .._version import __version__
+
+from .ipy import *
+from .pubsub import *
+from .ros_widgets import *
+from .ros3d import *
+from .server_extension import *
+from .turtle_sim import *

--- a/jupyros/ros1/ipy.py
+++ b/jupyros/ros1/ipy.py
@@ -5,14 +5,13 @@
 #                                                                           #
 # The full license is in the file LICENSE, distributed with this software.  #
 #############################################################################
-
-from IPython import get_ipython
-from IPython.core.magic import register_line_magic, register_cell_magic, register_line_cell_magic
-from threading import Thread
-import time
-from jupyros.pubsub import output_registry
-import ipywidgets as widgets
 import sys
+from threading import Thread
+
+import ipywidgets as widgets
+from IPython.core.magic import register_cell_magic
+
+from .pubsub import output_registry
 
 def executor(cell, gbls, lcls):
     exec(cell, gbls, lcls)

--- a/jupyros/ros1/pubsub.py
+++ b/jupyros/ros1/pubsub.py
@@ -8,17 +8,17 @@
 
 from __future__ import print_function
 
-import threading
-import time
-import ipywidgets as widgets
 import sys
+import threading
+
+import ipywidgets as widgets
 
 try:
     import rospy
 except:
+    print("The actionlib package is not found in your $PYTHONPATH. Action clients are not going to work.")
+    print("Do you need to activate your ROS environment?")
     pass
-
-import inspect
 
 output_registry = {}
 subscriber_registry = {}

--- a/jupyros/ros1/ros3d.py
+++ b/jupyros/ros1/ros3d.py
@@ -8,13 +8,10 @@
 
 import os
 
-import ipywidgets as widgets
 from traitlets import *
+import ipywidgets as widgets
 
-try:
-    from _version import version_info
-except:
-    from ._version import version_info
+from .._version import version_info
 
 js_version = '^' + '.'.join([str(x) for x in version_info[:3]])
 

--- a/jupyros/ros1/ros_widgets.py
+++ b/jupyros/ros1/ros_widgets.py
@@ -5,29 +5,35 @@
 #                                                                           #
 # The full license is in the file LICENSE, distributed with this software.  #
 #############################################################################
+import os
+import yaml
+import threading
+import subprocess
+import numpy as np
+
+import bqplot as bq
+import ipywidgets as widgets
+
 
 try:
     import rospy
 except:
     print("The rospy package is not found in your $PYTHONPATH. Subscribe and publish are not going to work.")
     print("Do you need to activate your ROS environment?")
-try:
-    from cv_bridge import CvBridge, CvBridgeError
-    import cv2
-
-    bridge = CvBridge()
-except:
-    pass
-import bqplot as bq
-import ipywidgets as widgets
-import numpy as np
-import threading
-import subprocess, yaml, os
 
 try: 
     import actionlib
 except:
     print("The actionlib package is not found in your $PYTHONPATH. Action clients are not going to work.")
+    print("Do you need to activate your ROS environment?")
+
+try:
+    from cv_bridge import CvBridge
+    import cv2
+
+    bridge = CvBridge()
+except:
+    pass
 
 
 def add_widgets(msg_instance, widget_dict, widget_list, prefix=''):

--- a/jupyros/ros1/server_extension.py
+++ b/jupyros/ros1/server_extension.py
@@ -5,15 +5,16 @@
 #                                                                           #
 # The full license is in the file LICENSE, distributed with this software.  #
 #############################################################################
+import os
 
 from notebook.utils import url_path_join
 from notebook.base.handlers import IPythonHandler
-from jupyros import _version
 
 import rospkg
-import os
 
-__version__ = _version.__version__
+from .._version import __version__
+
+__version__ = __version__
 
 if os.getenv('JUPYROS_DEFAULT_WS'):
     envs = os.getenv('JUPYROS_DEFAULT_WS').split(';')

--- a/jupyros/ros1/turtle_sim.py
+++ b/jupyros/ros1/turtle_sim.py
@@ -1,10 +1,12 @@
-import ipycanvas
-import ipywidgets
-import rospkg
-import random
+import os
 import time
 import math
-import os
+import random
+
+import ipycanvas
+import ipywidgets
+
+import rospkg
 
 
 class TurtleSim:

--- a/jupyros/ros2/__init__.py
+++ b/jupyros/ros2/__init__.py
@@ -1,0 +1,16 @@
+#############################################################################
+# Copyright (c) Wolf Vollprecht, QuantStack                                 #
+#                                                                           #
+# Distributed under the terms of the BSD 3-Clause License.                  #
+#                                                                           #
+# The full license is in the file LICENSE, distributed with this software.  #
+#############################################################################
+
+from .._version import __version__
+
+from ..ros1.ipy import *
+from ..ros1.pubsub import *
+from ..ros1.ros_widgets import *
+from ..ros1.ros3d import *
+from ..ros1.server_extension import *
+from ..ros1.turtle_sim import *


### PR DESCRIPTION
@wolfv 

I refactored the repo to separate ROS1 from ROS2 in two different sub-packages. By default jupyros still export everything from ros1, and at the moment, ros2 re-exports everything from ros1.
I'm not sure if we should create the ros1 folder. My idea is to prevent ROS2 users to import something that doesn't work on ROS2 by mistake.

With this organization, we can still import ROS1 as a default using:
`import jupyros` or `from jupyros import ros3d`
And at the same time have a separate package for ROS2:
`from jupyros import ros2` or `from jupyros.ros2 import ros3d`
