### PR TITLE
Import ROS1 or ROS2 modules based on environment

### DIFF
--- a/jupyros/__init__.py
+++ b/jupyros/__init__.py
@@ -7,13 +7,31 @@
 #############################################################################
 
 from ._version import version_info, __version__
+import os
 
-from .ros1.ipy import *
-from .ros1.pubsub import *
-from .ros1.ros_widgets import *
-from .ros1.ros3d import *
-from .ros1.server_extension import *
-from .ros1.turtle_sim import *
+try:
+    ros_version = os.environ['ROS_VERSION']
+    ros_distro = os.environ['ROS_DISTRO']
+except KeyError:
+    print('No ROS environment detected.')
+    print('Defaulting to ROS noetic.')
+    ros_version = '1'
+    ros_distro = 'noetic'
+
+if ros_version == '2':
+    # Import ROS2 modules
+    print(f'ROS2 {ros_distro} environment detected.')
+    # TODO: import modules once created
+else:
+    # Default to ROS1
+    print(f'ROS {ros_distro} environment detected.')
+    from .ros1.ipy import *
+    from .ros1.pubsub import *
+    from .ros1.ros_widgets import *
+    from .ros1.ros3d import *
+    from .ros1.server_extension import *
+    from .ros1.turtle_sim import *
+
 
 def _jupyter_nbextension_paths():
     return [{


### PR DESCRIPTION
Based on the environment variables for ROS, `jupyros` will import the corresponding modules for ROS1 or ROS2. If the ROS environment is not set up, it will automatically default to ROS1.