### PR TITLE
Rename `client` to `service_client`

### DIFF
--- a/docs/source/user_ros_essentials.rst
+++ b/docs/source/user_ros_essentials.rst
@@ -82,7 +82,7 @@ the following:
    from rospy_tutorials.srv import AddTwoInts
 
    rospy.init_node('service_node')
-   jupyros.client('service_name', AddTwoInts)
+   jupyros.service_client('service_name', AddTwoInts)
 
 The generated widget will change depending on the message type being passed.
 

--- a/jupyros/ros1/ros_widgets.py
+++ b/jupyros/ros1/ros_widgets.py
@@ -316,6 +316,16 @@ def bag_player(bagfile=''):
     return vbox
 
 
+def client(*args, **kwargs):
+    """
+    Deprecated client for ROS services.
+    Use service_client() instead.
+    """
+    from warnings import warn
+    warn("client() is deprecated. Use service_client() instead.")
+    return service_client(*args, **kwargs)
+
+
 def service_client(srv_name, srv_type):
     """
     Create a form widget for message type srv_type.

--- a/jupyros/ros1/ros_widgets.py
+++ b/jupyros/ros1/ros_widgets.py
@@ -316,7 +316,7 @@ def bag_player(bagfile=''):
     return vbox
 
 
-def client(srv_name, srv_type):
+def service_client(srv_name, srv_type):
     """
     Create a form widget for message type srv_type.
     This function analyzes the fields of srv_type and creates
@@ -327,7 +327,11 @@ def client(srv_name, srv_type):
 
     @return jupyter widget for display
     """
-    rospy.wait_for_service(srv_name, timeout=5)
+    try:
+        rospy.wait_for_service(srv_name, timeout=5)
+    except rospy.ROSException:
+        rospy.logerr(f"Service {srv_name} is unavailable.")
+        return
 
     widget_list = []
     widget_dict = {}
@@ -343,7 +347,7 @@ def client(srv_name, srv_type):
             service = rospy.ServiceProxy(srv_name, srv_type)
             return service(msg_to_send)
         except rospy.ServiceException as e:
-            print("Service call failed: %s" % e)
+            rospy.logerr(f"Service call failed: {e}")
 
     call_btn.on_click(call_srv)
 
@@ -373,7 +377,7 @@ def action_client(action_name, action_msg, goal_msg, callbacks=None):
 
     # Create actions client and connect to server
     a_client = actionlib.SimpleActionClient(action_name, action_msg)
-    rospy.loginfo(f'[{action_name.upper()}]: Waiting for action server.')
+    rospy.loginfo(f'[{action_name.upper()}] Waiting for action server.')
     server_ok = a_client.wait_for_server(timeout=rospy.Duration(5.0))
     if server_ok:
         rospy.loginfo(f'[{action_name.upper()}] Connection to server successful.')

--- a/notebooks/ROS_Services_Clients.ipynb
+++ b/notebooks/ROS_Services_Clients.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "jupyros.client('add_two_ints', AddTwoInts)"
+    "jupyros.service_client('add_two_ints', AddTwoInts)"
    ]
   }
  ],


### PR DESCRIPTION
With this PR, `client` is renamed to `service_client` to maintain consistency  and avoid confusion with the `action_client`. This change is updated in the example notebook and the documentation.

Additionally, error handling is improved for when the service is not available and a minor typo is corrected in the actions client (for consistency).