### PR TITLE
Removes prints for ros env

### DIFF
--- a/jupyros/__init__.py
+++ b/jupyros/__init__.py
@@ -13,18 +13,21 @@ try:
     ros_version = os.environ['ROS_VERSION']
     ros_distro = os.environ['ROS_DISTRO']
 except KeyError:
-    print('No ROS environment detected.')
-    print('Defaulting to ROS noetic.')
+    # print('No ROS environment detected.')
+    # print('Defaulting to ROS noetic.')
     ros_version = '1'
     ros_distro = 'noetic'
 
 if ros_version == '2':
     # Import ROS2 modules
-    print(f'ROS2 {ros_distro} environment detected.')
-    # TODO: import modules once created
+    # print(f'ROS2 {ros_distro} environment detected.')
+    from .ros2.publisher import *
+    from .ros2.ros_widgets import *
+    from .ros2.subscriber import *
+
 else:
     # Default to ROS1
-    print(f'ROS {ros_distro} environment detected.')
+    # print(f'ROS {ros_distro} environment detected.')
     from .ros1.ipy import *
     from .ros1.pubsub import *
     from .ros1.ros_widgets import *

--- a/jupyros/ros2/__init__.py
+++ b/jupyros/ros2/__init__.py
@@ -13,7 +13,6 @@ from .._version import __version__
 #from ..ros1.server_extension import *
 #from ..ros1.turtle_sim import *
 
-from ..ros2.ros_widgets import *
 from ..ros2.publisher import *
-
+from ..ros2.ros_widgets import *
 from ..ros2.subscriber import *

--- a/jupyros/ros2/publisher.py
+++ b/jupyros/ros2/publisher.py
@@ -11,7 +11,7 @@ from typing import TypeVar
 import threading
 import time
 import ipywidgets as widgets
-from . import add_widgets
+from .ros_widgets import add_widgets
 import functools
 
 def rsetattr(obj, attr, val):


### PR DESCRIPTION
When running `jupyter labextension develop . --overwrite`, JupyterLab tries to find the module by running `python setup.py --name` and then taking the command's output for the name of the package. Since we have some prints globally, those prints are executed when the module is evaluated, returning them as output to what makes the `jupyter labextension develop . --overwrite` command fails because it doesn't find the python module.