### PR TITLE
Automated Changelog Entry for 0.6.0 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.6.0
+
+([Full Changelog](https://github.com/robostack/jupyter-ros/compare/v0.6.0a0))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/robostack/jupyter-ros/graphs/contributors?from=2022-08-11&to=2022-09-06&type=c))
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.6.0a0
 
 ([Full Changelog](https://github.com/RoboStack/jupyter-ros/compare/0.5.0...1f6c46c9d24768a30817996445140d8ce956106d))
@@ -67,7 +77,5 @@
 ([GitHub contributors page for this release](https://github.com/RoboStack/jupyter-ros/graphs/contributors?from=2021-04-20&to=2022-08-11&type=c))
 
 [@dependabot](https://github.com/search?q=repo%3ARoboStack%2Fjupyter-ros+involves%3Adependabot+updated%3A2021-04-20..2022-08-11&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3ARoboStack%2Fjupyter-ros+involves%3Ahbcarlos+updated%3A2021-04-20..2022-08-11&type=Issues) | [@ihuicatl](https://github.com/search?q=repo%3ARoboStack%2Fjupyter-ros+involves%3Aihuicatl+updated%3A2021-04-20..2022-08-11&type=Issues) | [@ldania](https://github.com/search?q=repo%3ARoboStack%2Fjupyter-ros+involves%3Aldania+updated%3A2021-04-20..2022-08-11&type=Issues) | [@Tobias-Fischer](https://github.com/search?q=repo%3ARoboStack%2Fjupyter-ros+involves%3ATobias-Fischer+updated%3A2021-04-20..2022-08-11&type=Issues) | [@wolfv](https://github.com/search?q=repo%3ARoboStack%2Fjupyter-ros+involves%3Awolfv+updated%3A2021-04-20..2022-08-11&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.5.0


### PR DESCRIPTION
Automated Changelog Entry for 0.6.0 on master

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | robostack/jupyter-ros  |
| Branch  | master  |
| Version Spec | 0.6.0 |
| Since | v0.6.0a0 |