### PR TITLE
Fix error when building the extension

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["jupyter_packaging~=0.10,<0.12", "jupyterlab>=3,<4"]
+requires = ["jupyter_packaging~=0.10,!=0.12,<2", "jupyterlab>=3,<4"]
 build-backend = "jupyter_packaging.build_api"
 
 [tool.jupyter-packaging.options]


### PR DESCRIPTION
Currently, the extension fails the build check. This is potentially caused by ipywidgets=8.0 and jupyter-packaging=0.12
```
WARNING: Build tool `jupyter-packaging` is missing. Install it with pip or conda.
/home/miniconda3/env/lib/python3.9/site-packages/setuptools/config/expand.py:144: UserWarning: File '/home/repos/jupyter-ros-ipywidgets/README.rst' cannot be found
  warnings.warn(f"File {path!r} cannot be found")
/home/miniconda3/env/lib/python3.9/site-packages/setuptools/config/expand.py:144: UserWarning: File '/home/repos/jupyter-ros-ipywidgets/CHANGELOG.rst' cannot be found
  warnings.warn(f"File {path!r} cannot be found")
/home/miniconda3/env/lib/python3.9/site-packages/setuptools/config/expand.py:144: UserWarning: File '/home/repos/jupyter-ros-ipywidgets/LICENSE.rst' cannot be found
  warnings.warn(f"File {path!r} cannot be found")
INFO: signal_shutdown [atexit]
An error occurred.
pkg_resources.extern.packaging.requirements.InvalidRequirement: Parse error at "'actionli'": Expected string_end
```