### PR TITLE
Fix dev installation issue which errors out and prints truncated string

### DIFF
--- a/docs/source/dev_testing.rst
+++ b/docs/source/dev_testing.rst
@@ -32,7 +32,8 @@ environment and install the package in development mode.
             'bqplot',
             'numpy',
             'rospkg',
-            'ipycanvas'
+            'ipycanvas',
+            'notebook'
         ],
       }
 

--- a/jupyros/__init__.py
+++ b/jupyros/__init__.py
@@ -13,21 +13,17 @@ try:
     ros_version = os.environ['ROS_VERSION']
     ros_distro = os.environ['ROS_DISTRO']
 except KeyError:
-    # print('No ROS environment detected.')
-    # print('Defaulting to ROS noetic.')
     ros_version = '1'
     ros_distro = 'noetic'
 
 if ros_version == '2':
     # Import ROS2 modules
-    # print(f'ROS2 {ros_distro} environment detected.')
     from .ros2.publisher import *
     from .ros2.ros_widgets import *
     from .ros2.subscriber import *
 
 else:
     # Default to ROS1
-    # print(f'ROS {ros_distro} environment detected.')
     from .ros1.ipy import *
     from .ros1.pubsub import *
     from .ros1.ros_widgets import *

--- a/jupyros/ros1/pubsub.py
+++ b/jupyros/ros1/pubsub.py
@@ -10,15 +10,9 @@ from __future__ import print_function
 
 import sys
 import threading
-
 import ipywidgets as widgets
+import rospy
 
-try:
-    import rospy
-except:
-    print("The actionlib package is not found in your $PYTHONPATH. Action clients are not going to work.")
-    print("Do you need to activate your ROS environment?")
-    pass
 
 output_registry = {}
 subscriber_registry = {}

--- a/jupyros/ros1/ros_widgets.py
+++ b/jupyros/ros1/ros_widgets.py
@@ -10,22 +10,11 @@ import yaml
 import threading
 import subprocess
 import numpy as np
-
+import rospy
+import actionlib
 import bqplot as bq
 import ipywidgets as widgets
 
-
-try:
-    import rospy
-except:
-    print("The rospy package is not found in your $PYTHONPATH. Subscribe and publish are not going to work.")
-    print("Do you need to activate your ROS environment?")
-
-try: 
-    import actionlib
-except:
-    print("The actionlib package is not found in your $PYTHONPATH. Action clients are not going to work.")
-    print("Do you need to activate your ROS environment?")
 
 try:
     from cv_bridge import CvBridge

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 import json
 import sys
+import os
+import logging
 from pathlib import Path
 
 import setuptools
@@ -52,11 +54,12 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
     install_requires = [
-        'ipywidgets>=7.7.2,<8.0.0',
+        'ipywidgets>=7.7.2',
         'bqplot',
         'numpy',
         'rospkg',
-        'ipycanvas'
+        'ipycanvas',
+        'notebook'
     ],
     extras_require = {
         'dev': ['click','jupyter_releaser==0.22']
@@ -94,11 +97,27 @@ try:
     setup_args["cmdclass"] = wrap_installers(post_develop=post_develop, ensured_targets=ensured_targets)
     setup_args["data_files"] = get_data_files(data_files_spec)
 except ImportError as e:
-    import logging
     logging.basicConfig(format="%(levelname)s: %(message)s")
     logging.warning("Build tool `jupyter-packaging` is missing. Install it with pip or conda.")
     if not ("--name" in sys.argv or "--version" in sys.argv):
         raise e
+
+# Check for ROS environment
+try:
+    ros_version = os.environ['ROS_VERSION']
+except KeyError:
+    logging.error("No ROS environment detected. Please install ROS or ROS2.")
+
+# Check requirements for corresponding ROS distro
+try:
+    if ros_version == '2':
+        import rclpy
+    else:
+        import rospy
+        import actionlib
+        import rospkg
+except ImportError as e:
+    raise e
 
 if __name__ == "__main__":
     setuptools.setup(**setup_args)


### PR DESCRIPTION
`jupyros` currently has multiple print statements to warn the user about the packages required. These packages vary depending on which version of ROS is being used. `jupyter-packaging>0.11` fails to install the lab extension because of these print statements. The error shows a truncated string:
```
	pkg_resources.extern.packaging.requirements.InvalidRequirement: 
	Parse error at "'actionli'": Expected string_end
```

With this PR, these print statements are moved to the *setup.py* so that it fails before the package can be installed. Additionally, dependencies are updated.