### PR TITLE
Fix import issues with version

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           pip install .
       - name: Check Release
-        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
+        uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ include jupyros/_version.py
 include jupyros/__init__.py
 
 # Extensions
+graft js
 graft jupyros/nbextension
 graft jupyros/labextension
 include install.json

--- a/jupyros/_version.py
+++ b/jupyros/_version.py
@@ -28,16 +28,4 @@ def _fetchVersion():
 
     raise FileNotFoundError(f"Could not find package.json under dir {HERE!s}")
 
-def _fetchJSVersion():
-    HERE = Path(__file__).parent.parent.resolve()
-
-    for settings in HERE.rglob("package.json"):
-        try:
-            with settings.open() as f:
-                return json.load(f)["version"]
-        except FileNotFoundError:
-            pass
-
-    raise FileNotFoundError(f"Could not find package.json under dir {HERE!s}")
-
 __version__ = _fetchVersion()

--- a/jupyros/_version.py
+++ b/jupyros/_version.py
@@ -11,21 +11,24 @@ from pathlib import Path
 
 __all__ = ["__version__"]
 
-def _fetchVersion():
+def _fetchJSVersion():
     HERE = Path(__file__).parent.parent.resolve()
 
     for settings in HERE.rglob("package.json"):
         try:
             with settings.open() as f:
-                version = json.load(f)["version"]
-                return (
-                    version.replace("-alpha.", "a")
-                    .replace("-beta.", "b")
-                    .replace("-rc.", "rc")
-                )
+                return json.load(f)["version"]
         except FileNotFoundError:
             pass
 
     raise FileNotFoundError(f"Could not find package.json under dir {HERE!s}")
+
+def _fetchVersion():
+    version = _fetchJSVersion()
+    return (
+        version.replace("-alpha.", "a")
+            .replace("-beta.", "b")
+            .replace("-rc.", "rc")
+    )
 
 __version__ = _fetchVersion()

--- a/jupyros/ros1/ros3d.py
+++ b/jupyros/ros1/ros3d.py
@@ -11,7 +11,7 @@ import os
 from traitlets import *
 import ipywidgets as widgets
 
-from .._version import _fetchJSVersion
+from jupyros._version import _fetchJSVersion
 
 js_version = '^' + _fetchJSVersion()
 
@@ -539,5 +539,5 @@ if __name__ == "__main__":
     filedir = os.path.dirname(os.path.realpath(__file__))
 
     defaults_js = js_extract()
-    with open(os.path.join(filedir, "../js/lib/defaults.js"), "w") as fo:
+    with open(os.path.join(filedir, "../../js/lib/defaults.js"), "w") as fo:
         fo.write(defaults_js)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,6 @@ npm = ["jlpm"]
 [tool.check-manifest]
 ignore = ["jupyros/labextension/**", "jupyros/nbextension/**", "notebooks/**", "scripts/**", "docs/**", "js/dist/**", ".*"]
 
-[tool.jupyter-releaser]
-skip = []
-
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["python -m pip install jupyterlab"]
 before-build-npm = ["python -m pip install jupyterlab", "cd js && jlpm clean && jlpm"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ source_dir="lib"
 npm = ["jlpm"]
 
 [tool.check-manifest]
-ignore = ["jupyros/labextension/**", "jupyros/nbextension/**", "notebooks/**", "scripts/**", "docs/**", "js/**", ".*"]
+ignore = ["jupyros/labextension/**", "jupyros/nbextension/**", "notebooks/**", "scripts/**", "docs/**", ".*"]
 
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["python -m pip install jupyterlab", "cd js && jlpm clean"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ source_dir="lib"
 npm = ["jlpm"]
 
 [tool.check-manifest]
-ignore = ["jupyros/labextension/**", "jupyros/nbextension/**", "notebooks/**", "scripts/**", "docs/**", ".*"]
+ignore = ["jupyros/labextension/**", "jupyros/nbextension/**", "notebooks/**", "scripts/**", "docs/**", "js/dist/**", ".*"]
 
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["python -m pip install jupyterlab", "cd js && jlpm clean"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ npm = ["jlpm"]
 [tool.check-manifest]
 ignore = ["jupyros/labextension/**", "jupyros/nbextension/**", "notebooks/**", "scripts/**", "docs/**", "js/dist/**", ".*"]
 
+[tool.jupyter-releaser]
+skip = ["draft-changelog"]
+
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["python -m pip install jupyterlab"]
 before-build-npm = ["python -m pip install jupyterlab", "cd js && jlpm clean && jlpm"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ npm = ["jlpm"]
 ignore = ["jupyros/labextension/**", "jupyros/nbextension/**", "notebooks/**", "scripts/**", "docs/**", "js/dist/**", ".*"]
 
 [tool.jupyter-releaser]
-skip = ["draft-changelog"]
+skip = []
 
 [tool.jupyter-releaser.hooks]
 before-bump-version = ["python -m pip install jupyterlab"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ npm = ["jlpm"]
 ignore = ["jupyros/labextension/**", "jupyros/nbextension/**", "notebooks/**", "scripts/**", "docs/**", "js/dist/**", ".*"]
 
 [tool.jupyter-releaser.hooks]
-before-bump-version = ["python -m pip install jupyterlab", "cd js && jlpm clean"]
+before-bump-version = ["python -m pip install jupyterlab"]
 before-build-npm = ["python -m pip install jupyterlab", "cd js && jlpm clean && jlpm"]
 before-build-python = ["cd js && jlpm clean"]
 


### PR DESCRIPTION
The tar.gz package does not include the *js/* directory and the *package.json* file cannot be found in the root directory leading to the following error:
```python
import jupyros

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/.../lib/python3.9/site-packages/jupyros/__init__.py", line 9, in <module>
    from ._version import __version__
  File "/home/.../lib/python3.9/site-packages/jupyros/_version.py", line 43, in <module>
    __version__ = _fetchVersion()
  File "/home/.../lib/python3.9/site-packages/jupyros/_version.py", line 20, in _fetchVersion
    version = json.load(f)["version"]
KeyError: 'version'
```