### PR TITLE
Automated Changelog Entry for 0.7.0a0 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,29 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.7.0a0
+
+([Full Changelog](https://github.com/RoboStack/jupyter-ros/compare/0.6.0...b7ca8d717e1f752417fc24fa9b6b40b2cc8b03c7))
+
+### Enhancements made
+
+- Turtle [#142](https://github.com/RoboStack/jupyter-ros/pull/142) ([@ldania](https://github.com/ldania))
+
+### Other merged PRs
+
+- Fix #144 [#145](https://github.com/RoboStack/jupyter-ros/pull/145) ([@Andor233](https://github.com/Andor233))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/RoboStack/jupyter-ros/graphs/contributors?from=2022-09-14&to=2023-03-06&type=c))
+
+[@Andor233](https://github.com/search?q=repo%3ARoboStack%2Fjupyter-ros+involves%3AAndor233+updated%3A2022-09-14..2023-03-06&type=Issues) | [@hbcarlos](https://github.com/search?q=repo%3ARoboStack%2Fjupyter-ros+involves%3Ahbcarlos+updated%3A2022-09-14..2023-03-06&type=Issues) | [@ihuicatl](https://github.com/search?q=repo%3ARoboStack%2Fjupyter-ros+involves%3Aihuicatl+updated%3A2022-09-14..2023-03-06&type=Issues) | [@ldania](https://github.com/search?q=repo%3ARoboStack%2Fjupyter-ros+involves%3Aldania+updated%3A2022-09-14..2023-03-06&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.6.1
 
 ([Full Changelog](https://github.com/RoboStack/jupyter-ros/compare/v0.6.0...e9b3c9bbc85cc12944f487fb447b41e080f08cbc))
-
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.6.0
 


### PR DESCRIPTION
Automated Changelog Entry for 0.7.0a0 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | robostack/jupyter-ros  |
| Branch  | main  |
| Version Spec | 0.7.0-alpha.0 |
| Since Last Stable | true |